### PR TITLE
Accommodate correctly pluralized ViewStrings in GAP

### DIFF
--- a/gap/walrus.gd
+++ b/gap/walrus.gd
@@ -43,8 +43,7 @@
 #! One can also create pregroup presentations by giving a pregroup
 #! and relators, that is, words over the pregroup.
 #! @BeginExample
-#! gap> G1 := CyclicGroup(3);
-#! <pc group of size 3 with 1 generators>
+#! gap> G1 := CyclicGroup(3);;
 #! gap> pg := PregroupOfFreeProduct(G1,G1);
 #! <pregroup with 5 elements in table rep>
 #! gap> rel := [2,5,3,4,3,4,3,4,3,5,2,4,3,5,2,4,3,5,3,4,2,4,3,5];

--- a/tst/derek.tst
+++ b/tst/derek.tst
@@ -1,7 +1,6 @@
 # Examples that Derek sends me
 
-gap> G1 := CyclicGroup(3);
-<pc group of size 3 with 1 generators>
+gap> G1 := CyclicGroup(3);;
 gap> pg := PregroupOfFreeProduct(G1,G1);
 <pregroup with 5 elements in table rep>
 gap> rel := [2,5,3,4,3,4,3,4,3,5,2,4,3,5,2,4,3,5,3,4,2,4,3,5];


### PR DESCRIPTION
In some hopefully future version of GAP, some nouns will be correctly pluralised to match their number.  For example, `<pc group of size 3 with 1 generators>` will become `<pc group of size 3 with 1 generator>`.

The changes in this PR maintain the backwards and forwards compatibility of this package with GAP.

See gap-system/gap#3992 and gap-system/gap#4050 if you want more context.