### PR TITLE
Properly pluralize the ViewString for pregroup presentations

### DIFF
--- a/Polynomial-time proofs that groups are hyperbolic.ipynb
+++ b/Polynomial-time proofs that groups are hyperbolic.ipynb
@@ -60,7 +60,7 @@
     {
      "data": {
       "text/plain": [
-       "<pregroup presentation with 3 generators and 1 relators>"
+       "<pregroup presentation with 3 generators and 1 relator>"
       ]
      },
      "execution_count": 2,

--- a/doc/pregroups.xml
+++ b/doc/pregroups.xml
@@ -128,7 +128,7 @@ gap> pr := RandomPregroupPresentation(pg, 5, 20);
         epsilon value of <A>epsilon</A>.
         <Example><![CDATA[
 gap> tri_2_3_7 := TriangleGroup(2,3,7);
-<pregroup presentation with 3 generators and 1 relators>
+<pregroup presentation with 3 generators and 1 relator>
 gap> RSymTest(tri_2_3_7, 1/6);
 true
         ]]></Example>

--- a/gap/examples.gd
+++ b/gap/examples.gd
@@ -15,13 +15,13 @@
 #! <M>(xy)^r</M>.
 #! @BeginExample
 #! gap> T := TriangleGroup(2,3,7);
-#! <pregroup presentation with 3 generators and 1 relators>
+#! <pregroup presentation with 3 generators and 1 relator>
 #! gap> Pregroup(T);
 #! <pregroup with 4 elements in table rep>
 #! gap> Relators(T);
 #! [ <pregroup relator ([ "2", "3" ])^7> ]
 #! gap> T := TriangleGroup(17,22,100);
-#! <pregroup presentation with 37 generators and 1 relators>
+#! <pregroup presentation with 37 generators and 1 relator>
 #! gap> Pregroup(T);
 #! <pregroup with 38 elements in table rep>
 #! gap> Relators(T);

--- a/gap/presentation.gd
+++ b/gap/presentation.gd
@@ -133,7 +133,7 @@ DeclareGlobalFunction("PregroupPresentationToStream");
 #! gap> stream := InputTextString(str);
 #! InputTextString(0,146)
 #! gap> PregroupPresentationFromStream(stream);
-#! <pregroup presentation with 3 generators and 1 relators>
+#! <pregroup presentation with 3 generators and 1 relator>
 #! @EndExample
 DeclareGlobalFunction("PregroupPresentationFromStream");
 

--- a/gap/presentation.gi
+++ b/gap/presentation.gi
@@ -46,11 +46,25 @@ InstallMethod(ViewString
              , [IsPregroupPresentationRep],
 function(pgp)
     # Note that we do not really regard 1 as a generator
-    local res;
+    local res, Pluralize2;
+
+    # Remove this (and the suffix '2') when walrus requires GAP 4.12 or later
+    if CompareVersionNumbers(GAPInfo.Version, "4.12") then
+      Pluralize2 := Pluralize;
+    else
+      Pluralize2 := function(n, str)
+        if n <> 1 then
+          str := Concatenation(str, "s");
+        fi;
+        return Concatenation("\>", String(n), "\< ", str);
+      end;
+    fi;
 
     return STRINGIFY("<pregroup presentation with "
-                    , Size(pgp!.pg)-1, " generators and "
-                    , Length(pgp!.rels), " relators>");
+                    , Pluralize2(Size(pgp!.pg)-1, "generator")
+                    , " and "
+                    , Pluralize2(Length(pgp!.rels), "relator")
+                    , ">");
 end);
 
 InstallMethod(Pregroup

--- a/gap/walrus.gd
+++ b/gap/walrus.gd
@@ -29,11 +29,11 @@
 #! gives the algorithm a hint how hard it should try.
 #! @BeginExample
 #! gap> triangle := TriangleGroup(2,3,7);
-#! <pregroup presentation with 3 generators and 1 relators>
+#! <pregroup presentation with 3 generators and 1 relator>
 #! gap> IsHyperbolic(triangle, 1/6);
 #! true
 #! gap> triangle := TriangleGroup(3,3,3);
-#! <pregroup presentation with 3 generators and 1 relators>
+#! <pregroup presentation with 3 generators and 1 relator>
 #! gap> IsHyperbolic(triangle, 1/6);
 #! [ fail, [ [ 1, 0, 0, 0 ], [ 2, 1, 1, 1/36 ], [ 1, 2, 2, 1/18 ],
 #!          [ 2, 3, 3, 1/12 ], [ 1, 4, 4, 1/9 ], [ 2, 5, 5, 5/36 ],
@@ -49,7 +49,7 @@
 #! gap> rel := [2,5,3,4,3,4,3,4,3,5,2,4,3,5,2,4,3,5,3,4,2,4,3,5];
 #! [ 2, 5, 3, 4, 3, 4, 3, 4, 3, 5, 2, 4, 3, 5, 2, 4, 3, 5, 3, 4, 2, 4, 3, 5 ]
 #! gap> pgp := NewPregroupPresentation(pg,[pg_word(pg,rel)]);
-#! <pregroup presentation with 4 generators and 1 relators>
+#! <pregroup presentation with 4 generators and 1 relator>
 #! gap> res := RSymTest(pgp, 0);;
 #! gap> res[1];
 #! fail

--- a/tst/derek.tst
+++ b/tst/derek.tst
@@ -6,7 +6,7 @@ gap> pg := PregroupOfFreeProduct(G1,G1);
 gap> rel := [2,5,3,4,3,4,3,4,3,5,2,4,3,5,2,4,3,5,3,4,2,4,3,5];
 [ 2, 5, 3, 4, 3, 4, 3, 4, 3, 5, 2, 4, 3, 5, 2, 4, 3, 5, 3, 4, 2, 4, 3, 5 ]
 gap> pgp := NewPregroupPresentation(pg,[pg_word(pg,rel)]);
-<pregroup presentation with 4 generators and 1 relators>
+<pregroup presentation with 4 generators and 1 relator>
 gap> res := RSymTest(pgp, 0);;
 gap> IsList(res) and res[1] = fail;
 true

--- a/tst/standard/presentation.tst
+++ b/tst/standard/presentation.tst
@@ -1,6 +1,6 @@
 gap> START_TEST("ANATPH: presentation tests");
 gap> T := TriangleGroup(2,3,7);
-<pregroup presentation with 3 generators and 1 relators>
+<pregroup presentation with 3 generators and 1 relator>
 gap> Pregroup(T);
 <pregroup with 4 elements in table rep>
 gap> Relators(T);

--- a/tst/ui.tst
+++ b/tst/ui.tst
@@ -17,7 +17,7 @@ true
 gap> IsHyperbolic(F, rred, rgreen, 1/10);
 true
 gap> pgp := PregroupPresentationFromFp(F, rred, rgreen);
-<pregroup presentation with 6 generators and 1 relators>
+<pregroup presentation with 6 generators and 1 relator>
 gap> RSymTest(pgp, 1/10);
 true
 gap> IsHyperbolic(pgp, 1/10);


### PR DESCRIPTION
This makes use of the `Pluralize` function that was introduced in https://github.com/gap-system/gap/pull/3992, and will be included in GAP 4.12.

Obviously we can't require GAP 4.12 yet, because it doesn't exist, and even once it is released the use of `Pluralize` isn't in itself a good enough reason to require it.

So for now I have duplicated the relevant subset of the `Pluralize` function in this package. This can be removed once this package requires GAP 4.12 or later.