### PR TITLE
Rename Vertex to WalrusVertex

### DIFF
--- a/gap/place.gi
+++ b/gap/place.gi
@@ -81,7 +81,7 @@ function(P)
                 #T this check is new, and assuming the paper
                 #T is accurate correct
                 if DigraphVertexLabel(vg, v2)[1][2] = x then
-                    xi2 := Vertex(pres, v1, v, v2);
+                    xi2 := WalrusVertex(pres, v1, v, v2);
 
                     AddOrUpdate(res, [ __ID(Q), 1 ], xi1 + xi2);
                 fi;
@@ -143,7 +143,7 @@ function(P)
                     if DigraphVertexLabel(vg, v2)[1][1] = P2_outletterinv and
                        P2_letter = DigraphVertexLabel(vg, v2)[1][2] then
 
-                        xi1 := Vertex(pres, v1, v, v2);
+                        xi1 := WalrusVertex(pres, v1, v, v2);
                         if Colour(P2) = "green" then
                             AddOrUpdate(res, [ __ID(P2), len ], xi1);
 

--- a/gap/walrus.gd
+++ b/gap/walrus.gd
@@ -77,8 +77,8 @@
 DeclareGlobalFunction("CheckReducedDiagram");
 DeclareGlobalFunction("ComputePlaceTriples");
 
-# Not a good choice of name
-DeclareGlobalFunction("Vertex");
+# Vertex is an overloaded word, so name this WalrusVertex
+DeclareGlobalFunction("WalrusVertex");
 
 DeclareGlobalFunction("ShortBlobWords");
 

--- a/gap/walrus.gi
+++ b/gap/walrus.gi
@@ -199,7 +199,7 @@ function(pres)
     return vtl;
 end);
 
-InstallGlobalFunction(Vertex,
+InstallGlobalFunction(WalrusVertex,
 function(pres, v1, v, v2)
     local vt, t;
 


### PR DESCRIPTION
Per my prior comment, the name Vertex conflicts with xgap, and prevents loading Walrus on xgap or Gap.app.  This patch just renames Vertex to WalrusVertex.  I don't think that Vertex is even documented, so I don't expect that this causes any trouble.  I'm already shipping this patch in Gap.app.

Since none of the walrus commands with Vertex in their name seem to be documented, I would further suggest that they all be renamed following a similar style (e.g., VertexFor -> WalrusVertexFor).  But as I'm not certain that wouldn't cause trouble, this PR does not implement that bigger change.