### PR TITLE
fix a test

### DIFF
--- a/tst/dijkstra.tst
+++ b/tst/dijkstra.tst
@@ -25,8 +25,10 @@ gap> DigraphDijkstraS(C, 1);
       56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 
       74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 
       92, 93, 94, 95, 96, 97, 98, 99 ] ]
-gap> R := RandomDigraph(100, 0.05);;
-gap> l := DigraphDijkstraST(R, 1, 100);;
+gap> repeat
+>      R := RandomDigraph(100, 0.05);;
+>      l := DigraphDijkstraST(R, 1, 100);;
+>    until IsList( l );
 gap> Length(l); Length(l[1]); Length(l[2]);
 2
 100
@@ -36,8 +38,10 @@ gap> Length(l); Length(l[1]); Length(l[2]);
 2
 100
 100
-gap> R := RandomDigraph(100, 0.05);;
-gap> l := DigraphDijkstraST(R, 1, 100);;
+gap> repeat
+>      R := RandomDigraph(100, 0.05);;
+>      l := DigraphDijkstraST(R, 1, 100);;
+>    until IsList( l );
 gap> Length(l); Length(l[1]); Length(l[2]);
 2
 100

--- a/tst/standard/pregroup.tst
+++ b/tst/standard/pregroup.tst
@@ -15,4 +15,3 @@ fail
 gap> pgps := List(ANATPH_small_pregroups[6], tbl -> PregroupByTable([1..6], tbl));;
 gap> Length(pgps);
 28
-gap> STOP_TEST("ANATPH: pregroup tests", 1000);


### PR DESCRIPTION
Depending on the output of `RandomGraph`,
`DigraphDijkstraST` can return either a list or `infinity`. Up to now, a test assumed that the output is a list.

resolves #38 (Also a fix for digraphs/Digraphs/issues/929 would either fix this problem or cause that the test is always wrong.)